### PR TITLE
Filtering extension keys

### DIFF
--- a/src/main/java/com/deloitte/elrr/entity/Person.java
+++ b/src/main/java/com/deloitte/elrr/entity/Person.java
@@ -41,6 +41,8 @@ import lombok.Setter;
          AND org_assoc.id = :organizationId)
         OR (:organizationRelType = 'Employment'
             AND org_emp.id = :organizationId))
+    AND (CAST(:hasExtension AS text[]) IS NULL OR
+        p.extensions \\?\\?& CAST(:hasExtension AS text[]))
     """,
     resultClass = Person.class
 )

--- a/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
+++ b/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
@@ -20,8 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  *
  */
 
-@Service
-@Slf4j
+@Service @Slf4j
 public class PersonSvc implements CommonSvc<Person, UUID> {
 
     private final PersonRepository personRepository;
@@ -75,11 +74,18 @@ public class PersonSvc implements CommonSvc<Person, UUID> {
      * @param ifi Optional IFI (Inverse Functional Identifier) filter
      * @param organizationId Optional organization ID filter
      * @param organizationRelType Optional organization relationship type filter
+     * @param hasExtension Optional filter for extension keys
      * @return List of persons matching the criteria
      */
     public List<Person> findPersonsWithFilters(final UUID id, final String ifi,
-            final UUID organizationId, final String organizationRelType) {
+            final UUID organizationId, final String organizationRelType,
+            final List<String> hasExtension) {
+
+        // Convert hasExtension to Stringp[] for the query
+        String[] hasExtensionArray = hasExtension != null
+                ? hasExtension.toArray(new String[0])
+                : null;
         return personRepository.findPersonsWithFilters(id, ifi, organizationId,
-                organizationRelType);
+                organizationRelType, hasExtensionArray);
     }
 }

--- a/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
+++ b/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
@@ -79,13 +79,9 @@ public class PersonSvc implements CommonSvc<Person, UUID> {
      */
     public List<Person> findPersonsWithFilters(final UUID id, final String ifi,
             final UUID organizationId, final String organizationRelType,
-            final List<String> hasExtension) {
+            final String[] hasExtension) {
 
-        // Convert hasExtension to Stringp[] for the query
-        String[] hasExtensionArray = hasExtension != null
-                ? hasExtension.toArray(new String[0])
-                : null;
         return personRepository.findPersonsWithFilters(id, ifi, organizationId,
-                organizationRelType, hasExtensionArray);
+                organizationRelType, hasExtension);
     }
 }

--- a/src/main/java/com/deloitte/elrr/repository/PersonRepository.java
+++ b/src/main/java/com/deloitte/elrr/repository/PersonRepository.java
@@ -19,12 +19,14 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
      * @param ifi Optional IFI (Inverse Functional Identifier) filter
      * @param organizationId Optional organization ID filter
      * @param organizationRelType Optional organization relationship type filter
+     * @param hasExtension Optional filter for extension keys
      * @return List of persons matching the criteria
      */
     List<Person> findPersonsWithFilters(
             @Param("id") UUID id,
             @Param("ifi") String ifi,
             @Param("organizationId") UUID organizationId,
-            @Param("organizationRelType") String organizationRelType);
+            @Param("organizationRelType") String organizationRelType,
+            @Param("hasExtension") String[] hasExtension);
 
 }

--- a/src/test/java/com/deloitte/elrr/jpa/svc/PersonSvcTest.java
+++ b/src/test/java/com/deloitte/elrr/jpa/svc/PersonSvcTest.java
@@ -87,8 +87,8 @@ public class PersonSvcTest {
     @Test
     void findPersonsWithFiltersTest() {
         Mockito.doReturn(getTestPeople()).when(personRepository)
-                .findPersonsWithFilters(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
-        Iterable<Person> people = personSvc.findPersonsWithFilters(null, null, null, null);
+                .findPersonsWithFilters(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        Iterable<Person> people = personSvc.findPersonsWithFilters(null, null, null, null, null);
         assertEquals(Iterables.size(people), 1);
     }
 


### PR DESCRIPTION
Add new param `hasExtension` that represents keys that must be in the extensions map.