### PR TITLE
Filtering by jsonpath

### DIFF
--- a/src/main/java/com/deloitte/elrr/entity/Person.java
+++ b/src/main/java/com/deloitte/elrr/entity/Person.java
@@ -33,14 +33,18 @@ import lombok.Setter;
         ON a.organization_id = org_assoc.id
     LEFT JOIN {h-schema}organization org_emp
         ON er.employer_organization = org_emp.id
+    -- by ID, TODO: make multiple IDs work
     WHERE (CAST(:id AS uuid) IS NULL OR p.id = :id)
+    -- by IFI, TODO: make multiple IFIs work
     AND (CAST(:ifi AS text) IS NULL OR i.ifi = :ifi)
+    -- by organization, via association or employment
     AND (CAST(:organizationId AS uuid) IS NULL OR
         ((CAST(:organizationRelType AS text) IS NULL
             OR :organizationRelType = 'Association')
          AND org_assoc.id = :organizationId)
         OR (:organizationRelType = 'Employment'
             AND org_emp.id = :organizationId))
+    -- by presence of (all) extension keys
     AND (CAST(:hasExtension AS text[]) IS NULL OR
         p.extensions \\?\\?& CAST(:hasExtension AS text[]))
     """,

--- a/src/main/java/com/deloitte/elrr/entity/Person.java
+++ b/src/main/java/com/deloitte/elrr/entity/Person.java
@@ -51,6 +51,10 @@ import lombok.Setter;
     AND (CAST(:extensionPath AS text[]) IS NULL OR
         (SELECT bool_and(p.extensions @\\?\\? path::jsonpath)
          FROM unnest(CAST(:extensionPath AS text[])) AS path))
+    -- by returning items from all jsonpath predicates
+    AND (CAST(:extensionPathMatch AS text[]) IS NULL OR
+        (SELECT bool_and(p.extensions @@ path::jsonpath)
+         FROM unnest(CAST(:extensionPathMatch AS text[])) AS path))
     """,
     resultClass = Person.class
 )

--- a/src/main/java/com/deloitte/elrr/entity/Person.java
+++ b/src/main/java/com/deloitte/elrr/entity/Person.java
@@ -47,6 +47,10 @@ import lombok.Setter;
     -- by presence of (all) extension keys
     AND (CAST(:hasExtension AS text[]) IS NULL OR
         p.extensions \\?\\?& CAST(:hasExtension AS text[]))
+    -- by returning items from all jsonpath queries
+    AND (CAST(:extensionPath AS text[]) IS NULL OR
+        (SELECT bool_and(p.extensions @\\?\\? path::jsonpath)
+         FROM unnest(CAST(:extensionPath AS text[])) AS path))
     """,
     resultClass = Person.class
 )

--- a/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
+++ b/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
@@ -76,13 +76,15 @@ public class PersonSvc implements CommonSvc<Person, UUID> {
      * @param organizationId Optional organization ID filter
      * @param organizationRelType Optional organization relationship type filter
      * @param hasExtension Optional filter for extension keys
+     * @param extensionPath Optional filter for JSONPath expressions
      * @return List of persons matching the criteria
      */
     public List<Person> findPersonsWithFilters(final UUID id, final String ifi,
             final UUID organizationId, final String organizationRelType,
-            final String[] hasExtension) {
+            final String[] hasExtension,
+            final String[] extensionPath) {
 
         return personRepository.findPersonsWithFilters(id, ifi, organizationId,
-                organizationRelType, hasExtension);
+                organizationRelType, hasExtension, extensionPath);
     }
 }

--- a/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
+++ b/src/main/java/com/deloitte/elrr/jpa/svc/PersonSvc.java
@@ -77,14 +77,17 @@ public class PersonSvc implements CommonSvc<Person, UUID> {
      * @param organizationRelType Optional organization relationship type filter
      * @param hasExtension Optional filter for extension keys
      * @param extensionPath Optional filter for JSONPath expressions
+     * @param extensionPathMatch Optional filter for JSONPath predicates
      * @return List of persons matching the criteria
      */
     public List<Person> findPersonsWithFilters(final UUID id, final String ifi,
             final UUID organizationId, final String organizationRelType,
             final String[] hasExtension,
-            final String[] extensionPath) {
+            final String[] extensionPath,
+            final String[] extensionPathMatch) {
 
         return personRepository.findPersonsWithFilters(id, ifi, organizationId,
-                organizationRelType, hasExtension, extensionPath);
+                organizationRelType, hasExtension,
+                extensionPath, extensionPathMatch);
     }
 }

--- a/src/main/java/com/deloitte/elrr/repository/PersonRepository.java
+++ b/src/main/java/com/deloitte/elrr/repository/PersonRepository.java
@@ -20,6 +20,7 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
      * @param organizationId Optional organization ID filter
      * @param organizationRelType Optional organization relationship type filter
      * @param hasExtension Optional filter for extension keys
+     * @param extensionPath Optional filter for JSONPath expressions
      * @return List of persons matching the criteria
      */
     List<Person> findPersonsWithFilters(
@@ -27,6 +28,7 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
             @Param("ifi") String ifi,
             @Param("organizationId") UUID organizationId,
             @Param("organizationRelType") String organizationRelType,
-            @Param("hasExtension") String[] hasExtension);
+            @Param("hasExtension") String[] hasExtension,
+            @Param("extensionPath") String[] extensionPath);
 
 }

--- a/src/main/java/com/deloitte/elrr/repository/PersonRepository.java
+++ b/src/main/java/com/deloitte/elrr/repository/PersonRepository.java
@@ -21,6 +21,7 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
      * @param organizationRelType Optional organization relationship type filter
      * @param hasExtension Optional filter for extension keys
      * @param extensionPath Optional filter for JSONPath expressions
+     * @param extensionPathMatch Optional filter for JSONPath predicates
      * @return List of persons matching the criteria
      */
     List<Person> findPersonsWithFilters(
@@ -29,6 +30,6 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
             @Param("organizationId") UUID organizationId,
             @Param("organizationRelType") String organizationRelType,
             @Param("hasExtension") String[] hasExtension,
-            @Param("extensionPath") String[] extensionPath);
-
+            @Param("extensionPath") String[] extensionPath,
+            @Param("extensionPathMatch") String[] extensionPathMatch);
 }

--- a/src/test/java/com/deloitte/elrr/jpa/svc/PersonSvcTest.java
+++ b/src/test/java/com/deloitte/elrr/jpa/svc/PersonSvcTest.java
@@ -87,8 +87,8 @@ public class PersonSvcTest {
     @Test
     void findPersonsWithFiltersTest() {
         Mockito.doReturn(getTestPeople()).when(personRepository)
-                .findPersonsWithFilters(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
-        Iterable<Person> people = personSvc.findPersonsWithFilters(null, null, null, null, null);
+                .findPersonsWithFilters(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        Iterable<Person> people = personSvc.findPersonsWithFilters(null, null, null, null, null, null);
         assertEquals(Iterables.size(people), 1);
     }
 

--- a/src/test/java/com/deloitte/elrr/jpa/svc/PersonSvcTest.java
+++ b/src/test/java/com/deloitte/elrr/jpa/svc/PersonSvcTest.java
@@ -87,8 +87,8 @@ public class PersonSvcTest {
     @Test
     void findPersonsWithFiltersTest() {
         Mockito.doReturn(getTestPeople()).when(personRepository)
-                .findPersonsWithFilters(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
-        Iterable<Person> people = personSvc.findPersonsWithFilters(null, null, null, null, null, null);
+                .findPersonsWithFilters(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        Iterable<Person> people = personSvc.findPersonsWithFilters(null, null, null, null, null, null, null);
         assertEquals(Iterables.size(people), 1);
     }
 


### PR DESCRIPTION
Adds two query parameters:
* `extensionPath` is a collection of JSONPath expressions, all of which must return a result to return the record.
* `extensionPathMatch` is a collection of JSONPath predicate expressions, all of which must return a true result to return the record.
